### PR TITLE
Fix: fetch with retry

### DIFF
--- a/src/lib/client/nova.ts
+++ b/src/lib/client/nova.ts
@@ -11,6 +11,7 @@ import {
 } from "babyjubjub-ecdsa";
 import { TreeRoots } from "@/pages/api/tree/root";
 import { TreeType } from "./indexDB";
+import { fetchWithRetry } from "./utils";
 
 export type NovaWasm = typeof import("bjj_ecdsa_nova_wasm");
 
@@ -47,7 +48,7 @@ export class MembershipFolder {
     // get wasm
     let wasm = await getWasm();
     // get tree roots
-    let roots: TreeRoots = await fetch("/api/tree/root").then(
+    let roots: TreeRoots = await fetchWithRetry("/api/tree/root").then(
       async (res) => await res.json()
     );
     // get params
@@ -65,7 +66,7 @@ export class MembershipFolder {
     // get wasm
     // let wasm = await getWasm();
     // get tree roots
-    let roots: TreeRoots = await fetch("/api/tree/root").then(
+    let roots: TreeRoots = await fetchWithRetry("/api/tree/root").then(
       async (res) => await res.json()
     );
 
@@ -98,7 +99,7 @@ export class MembershipFolder {
     treeType: TreeType
   ): Promise<string> {
     // fetch merkle proof for the user
-    const merkleProof = await fetch(
+    const merkleProof = await fetchWithRetry(
       `/api/tree/proof?treeType=${treeType}&pubkey=${pk}`
     )
       .then(async (res) => await res.json())
@@ -137,7 +138,7 @@ export class MembershipFolder {
     treeType: "attendee" | "speaker" | "talk"
   ): Promise<string> {
     // fetch merkle proof for the user
-    const merkleProof = await fetch(
+    const merkleProof = await fetchWithRetry(
       `/api/tree/proof?treeType=${treeType}&pubkey=${pk}`
     )
       .then(async (res) => await res.json())
@@ -295,7 +296,7 @@ export const getAllParamsByChunk = async (): Promise<string> => {
   for (let i = 0; i < 10; i++) {
     let req = async () => {
       let full_url = `${process.env.NEXT_PUBLIC_NOVA_BUCKET_URL}/params_${i}.gz`;
-      let res = await fetch(full_url, {
+      let res = await fetchWithRetry(full_url, {
         headers: { "Content-Type": "application/x-binary" },
       }).then(async (res) => await res.blob());
       data.set(i, res);

--- a/src/lib/client/utils.ts
+++ b/src/lib/client/utils.ts
@@ -76,6 +76,7 @@ export const fetchWithRetry = async (
     }
     return response;
   } catch (e) {
+    console.log(`Failed fetch of "${url}" with ${retries} retries left`);
     if (retries > 0) {
       await new Promise(resolve => setTimeout(resolve, backoff));
       return fetchWithRetry(url, options, retries - 1, backoff * 2);

--- a/src/lib/client/utils.ts
+++ b/src/lib/client/utils.ts
@@ -54,3 +54,33 @@ export const handleUsername = (username?: string): string => {
   }
   return `@${username}`;
 };
+
+/**
+ * Makes a fetch request and retries it a specified number of times until success
+ * 
+ * @param url - the url to make http request to
+ * @param options - request options
+ * @param retries - number of times to retry
+ * @param backoff - delay period before retrying
+ */
+export const fetchWithRetry = async (
+  url: string,
+  options?: RequestInit,
+  retries: number = 3,
+  backoff: number = 200
+): Promise<Response> => {
+  try {
+    const response = await fetch(url, options);
+    if (!response.ok && retries > 0) {
+      throw new Error("Fetch failed");
+    }
+    return response;
+  } catch (e) {
+    if (retries > 0) {
+      await new Promise(resolve => setTimeout(resolve, backoff));
+      return fetchWithRetry(url, options, retries - 1, backoff * 2);
+    } else {
+      throw e;
+    }
+  }
+}

--- a/src/pages/folded/[id].tsx
+++ b/src/pages/folded/[id].tsx
@@ -10,6 +10,7 @@ import { GetFoldingProofResponse } from "../api/folding/proof";
 import { Spinner } from "@/components/Spinner";
 import { useWorker } from "@/hooks/useWorker";
 import Link from "next/link";
+import { fetchWithRetry } from "@/lib/client/utils";
 
 type UserProofs = {
   attendee?: {
@@ -144,14 +145,14 @@ const Folded = (): JSX.Element => {
   useEffect(() => {
     (async () => {
       // Check if proof id exists or not
-      const response = await fetch(`/api/folding/proof?proofUuid=${id}`);
+      const response = await fetchWithRetry(`/api/folding/proof?proofUuid=${id}`);
       if (response.ok) {
         // get proof data for the user
         const foldingData: GetFoldingProofResponse = await response.json();
         // get blobs for each proof type
         const proofBlobs: Map<TreeType, Blob> = new Map();
         const getProof = async (uri: string, treeType: TreeType) => {
-          const proof = await fetch(uri).then(async (res) => await res.blob());
+          const proof = await fetchWithRetry(uri).then(async (res) => await res.blob());
           proofBlobs.set(treeType, proof);
         };
         let requests = [];


### PR DESCRIPTION
fetch of tree roots will occasionally fail. Pr adds 'fetchWithRetry' which makes a fetch request and retries it a given # of times with a backoff period. In all implementation, retries 3 times with 200, 400, and 800ms 